### PR TITLE
Simplified notification printing

### DIFF
--- a/reconbot/notificationprinters/esi/formatter.py
+++ b/reconbot/notificationprinters/esi/formatter.py
@@ -1,0 +1,26 @@
+import re
+
+class Formatter(object):
+
+    def __init__(self, printer, notification):
+        self.printer = printer
+        self.notification = notification
+
+    def __format__(self, format):
+        pattern = r'([a-zA-Z_]+)\(([a-zA-Z_]+)\)'
+        matches = re.match(pattern, format)
+        if not matches:
+            return format
+
+        if not hasattr(self.printer, matches.group(1)):
+            raise Exception('Unknown method "%s" in format "%s"' % (matches.group(1), format))
+
+        method = getattr(self.printer, matches.group(1))
+        key = matches.group(2)
+
+        if key not in self.notification:
+            raise Exception('Unknown attribute "%s" in notification "%s"' % (key, repr(self.notification)))
+
+        arg = self.notification[key]
+
+        return method(arg)

--- a/reconbot/notificationprinters/esi/formatter.py
+++ b/reconbot/notificationprinters/esi/formatter.py
@@ -7,20 +7,23 @@ class Formatter(object):
         self.notification = notification
 
     def __format__(self, format):
-        pattern = r'([a-zA-Z_]+)\(([a-zA-Z_]+)\)'
+        pattern = r'([a-zA-Z_]+)\(([a-zA-Z_]+)(?:\s*,\s*([a-zA-Z_]+))?\)'
         matches = re.match(pattern, format)
         if not matches:
             return format
+        groups = matches.groups()
 
-        if not hasattr(self.printer, matches.group(1)):
+        if not hasattr(self.printer, groups[0]):
             raise Exception('Unknown method "%s" in format "%s"' % (matches.group(1), format))
 
-        method = getattr(self.printer, matches.group(1))
-        key = matches.group(2)
+        method = getattr(self.printer, groups[0])
 
-        if key not in self.notification:
-            raise Exception('Unknown attribute "%s" in notification "%s"' % (key, repr(self.notification)))
+        keys = list(filter(lambda k: k is not None, groups[1:]))
 
-        arg = self.notification[key]
+        for key in keys:
+            if key not in self.notification:
+                raise Exception('Unknown attribute "%s" in notification "%s"' % (key, repr(self.notification)))
 
-        return method(arg)
+        args = list(map(lambda key: self.notification[key], keys))
+
+        return method(*args)

--- a/reconbot/notificationprinters/esi/printer.py
+++ b/reconbot/notificationprinters/esi/printer.py
@@ -109,15 +109,9 @@ class Printer(object):
         return '{0:get_moon(moonID)} POS "{0:get_item(typeID)}" ({0:get_percentage(shieldValue)} shield, {0:get_percentage(armorValue)} armor, {0:get_percentage(hullValue)} hull) under attack by {0:get_character(aggressorID)}'.format(Formatter(self, notification))
 
     def pos_fuel_alert(self, notification):
-        moon = self.get_moon(notification['moonID'])
-        item_type = self.get_item(notification['typeID'])
         wants = map(lambda w: '%s: %d' % (self.get_item(w['typeID']), w['quantity']), notification['wants'])
 
-        return "%s POS \"%s\" is low on fuel: %s" % (
-            moon,
-            item_type,
-            ', '.join(wants)
-        )
+        return '{0:get_moon(moonID)} POS "{0:get_item(typeID)}" is low on fuel: {wants}'.format(Formatter(self, notification), wants=', '.join(wants))
 
     def station_conquered(self, notification):
         return "Station conquered from {0:get_corporation(oldOwnerID)} by {0:get_corporation(newOwnerID)} in {0:get_system(solarSystemID)}".format(Formatter(self, notification))
@@ -129,19 +123,7 @@ class Printer(object):
         return '"{0:get_planet(planetID)}" POCO has been reinforced by {0:get_character(aggressorID)} (comes out of reinforce on "{0:eve_timestamp_to_date(reinforceExitTime)}")'.format(Formatter(self, notification))
 
     def structure_transferred(self, notification):
-        from_corporation = self.get_corporation(notification['fromCorporationLinkData'][-1])
-        to_corporation = self.get_corporation(notification['toCorporationLinkData'][-1])
-        structure = notification['structureName']
-        system = self.get_system(notification['solarSystemLinkData'][-1])
-        character = self.get_character(notification['characterLinkData'][-1])
-
-        return "\"%s\" structure in %s has been transferred from %s to %s by %s" % (
-            structure,
-            system,
-            from_corporation,
-            to_corporation,
-            character
-        )
+        return '"{0:get_string(structureName)}" structure in {0:get_system_from_link(solarSystemLinkData)} has been transferred from {0:get_corporation_from_link(fromCorporationLinkData)} to {0:get_corporation_from_link(toCorporationLinkData)} by {0:get_character_from_link(characterLinkData)}'.format(Formatter(self, notification))
 
     def entosis_capture_started(self, notification):
         return 'Capturing of "{0:get_item(structureTypeID)}" in {0:get_system(solarSystemID)} has started'.format(Formatter(self, notification))
@@ -165,112 +147,34 @@ class Printer(object):
         return 'SOV structure "{0:get_item(structureTypeID)}" in {0:get_system(solarSystemID)} has been freeported, exits freeport on "{0:eve_timestamp_to_date(freeportexittime)}"'.format(Formatter(self, notification))
 
     def citadel_low_fuel(self, notification):
-        citadel_type = self.get_item(notification['structureShowInfoData'][1])
-        system = self.get_system(notification['solarsystemID'])
-        citadel_name = self.get_structure_name(notification['structureID'])
-
-        return "Citadel (%s, \"%s\") low fuel alert in %s" % (
-            citadel_type,
-            citadel_name,
-            system)
+        return 'Citadel ({0:get_structure_type_from_link(structureShowInfoData)}, "{0:get_structure_name(structureID)}") low fuel alert in {0:get_system(solarsystemID)}'.format(Formatter(self, notification))
 
     def citadel_anchored(self, notification):
-        citadel_type = self.get_item(notification['structureShowInfoData'][1])
-        system = self.get_system(notification['solarsystemID'])
-        corp = self.get_corporation(notification['ownerCorpLinkData'][-1])
-        citadel_name = self.get_structure_name(notification['structureID'])
-
-        return "Citadel (%s, \"%s\") anchored in %s by %s" % (
-            citadel_type,
-            citadel_name,
-            system,
-            corp)
+        return 'Citadel ({0:get_structure_type_from_link(structureShowInfoData)}, "{0:get_structure_name(structureID)}") anchored in {0:get_system(solarsystemID)} by {0:get_corporation_from_link(ownerCorpLinkData)}'.format(Formatter(self, notification))
 
     def citadel_unanchoring(self, notification):
-        citadel_type = self.get_item(notification['structureShowInfoData'][1])
-        system = self.get_system(notification['solarsystemID'])
-        corp = self.get_corporation(notification['ownerCorpLinkData'][-1])
-        citadel_name = self.get_structure_name(notification['structureID'])
-
-        return "Citadel (%s, \"%s\") unanchoring in %s by %s" % (
-            citadel_type,
-            citadel_name,
-            system,
-            corp)
+        return 'Citadel ({0:get_structure_type_from_link(structureShowInfoData)}, "{0:get_structure_name(structureID)}") unanchoring in {0:get_system(solarsystemID)} by {0:get_corporation_from_link(ownerCorpLinkData)}'.format(Formatter(self, notification))
 
 
     def citadel_attacked(self, notification):
-        citadel_type = self.get_item(notification['structureShowInfoData'][1])
-        system = self.get_system(notification['solarsystemID'])
-        attacker = self.get_character(notification['charID'])
-        citadel_name = self.get_structure_name(notification['structureID'])
-
-        return "Citadel (%s, \"%s\") attacked (%.1f%% shield, %.1f%% armor, %.1f%% hull) in %s by %s" % (
-            citadel_type,
-            citadel_name,
-            notification['shieldPercentage'],
-            notification['armorPercentage'],
-            notification['hullPercentage'],
-            system,
-            attacker)
+        return 'Citadel ({0:get_structure_type_from_link(structureShowInfoData)}, "{0:get_structure_name(structureID)}") attacked ({0:get_percentage(shieldPercentage)} shield, {0:get_percentage(armorPercentage)} armor, {0:get_percentage(hullPercentage)} hull) in {0:get_system(solarsystemID)} by {0:get_character(charID)}'.format(Formatter(self, notification))
 
     def citadel_onlined(self, notification):
-        citadel_type = self.get_item(notification['structureShowInfoData'][1])
-        system = self.get_system(notification['solarsystemID'])
-        citadel_name = self.get_structure_name(notification['structureID'])
-
-        return "Citadel (%s, \"%s\") onlined in %s" % (
-            citadel_type,
-            citadel_name,
-            system)
+        return 'Citadel ({0:get_structure_type_from_link(structureShowInfoData)}, "{0:get_structure_name(structureID)}") onlined in {0:get_system(solarsystemID)}'.format(Formatter(self, notification))
 
     def citadel_lost_shields(self, notification):
-        citadel_type = self.get_item(notification['structureShowInfoData'][1])
-        system = self.get_system(notification['solarsystemID'])
-        citadel_name = self.get_structure_name(notification['structureID'])
-        timestamp = self.eve_duration_to_date(notification['notification_timestamp'], notification['timeLeft'])
-
-        return "Citadel (%s, \"%s\") lost shields in %s (comes out of reinforce on \"%s\")" % (
-            citadel_type,
-            citadel_name,
-            system,
-            timestamp)
+        return 'Citadel ({0:get_structure_type_from_link(structureShowInfoData)}, "{0:get_structure_name(structureID)}") lost shields in {0:get_system(solarsystemID)} (comes out of reinforce on "{0:eve_duration_to_date(notification_timestamp, timeLeft)}")'.format(Formatter(self, notification))
 
     def citadel_lost_armor(self, notification):
-        citadel_type = self.get_item(notification['structureShowInfoData'][1])
-        system = self.get_system(notification['solarsystemID'])
-        citadel_name = self.get_structure_name(notification['structureID'])
-        timestamp = self.eve_duration_to_date(notification['notification_timestamp'], notification['timeLeft'])
-
-        return "Citadel (%s, \"%s\") lost armor in %s (comes out of reinforce on \"%s\")" % (
-            citadel_type,
-            citadel_name,
-            system,
-            timestamp)
+        return 'Citadel ({0:get_structure_type_from_link(structureShowInfoData)}, "{0:get_structure_name(structureID)}") lost armor in {0:get_system(solarsystemID)} (comes out of reinforce on "{0:eve_duration_to_date(notification_timestamp, timeLeft)}")'.format(Formatter(self, notification))
 
     def citadel_destroyed(self, notification):
-        citadel_type = self.get_item(notification['structureShowInfoData'][1])
-        system = self.get_system(notification['solarsystemID'])
-        corp = self.get_corporation(notification['ownerCorpLinkData'][-1])
-        citadel_name = self.get_structure_name(notification['structureID'])
-
-        return "Citadel (%s, \"%s\") destroyed in %s owned by %s" % (
-            citadel_type,
-            citadel_name,
-            system,
-            corp)
+        return 'Citadel ({0:get_structure_type_from_link(structureShowInfoData)}, "{0:get_structure_name(structureID)}") destroyed in {0:get_system(solarsystemID)} owned by {0:get_corporation_from_link(ownerCorpLinkData)}'.format(Formatter(self, notification))
 
     def citadel_out_of_fuel(self, notification):
-        system = self.get_system(notification['solarsystemID'])
-        citadel_type = self.get_item(notification['structureShowInfoData'][1])
         services = map(lambda ID: self.get_item(ID), notification['listOfServiceModuleIDs'])
-        citadel_name = self.get_structure_name(notification['structureID'])
 
-        return "Citadel (%s, \"%s\") ran out of fuel in %s with services \"%s\"" % (
-            citadel_type,
-            citadel_name,
-            system,
-            ', '.join(services))
+        return 'Citadel ({0:get_structure_type_from_link(structureShowInfoData)}, "{0:get_structure_name(structureID)}") ran out of fuel in {0:get_system(solarsystemID)} with services "{services}"'.format(Formatter(self, notification), services=', '.join(services))
 
     def structure_anchoring_alert(self, notification):
         return 'New structure ({0:get_item(typeID)}) anchored in "{0:get_moon(moonID)}" by {0:get_corporation(corpID)}'.format(Formatter(self, notification))
@@ -420,10 +324,24 @@ class Printer(object):
         return timedelta.strftime('%Y-%m-%d %H:%M:%S')
 
     def get_percentage(self, value):
-        return '%.1f%%' % (value * 100)
+        if value <= 1:
+            value = value * 100
+        return '%.1f%%' % value
 
     def get_isk(self, isk):
         return '%.2f ISK' % isk
 
     def get_string(self, value):
         return str(value)
+
+    def get_corporation_from_link(self, show_info):
+        return self.get_corporation(show_info[-1])
+
+    def get_structure_type_from_link(self, show_info):
+        return self.get_item(show_info[1])
+
+    def get_system_from_link(self, show_info):
+        return self.get_system(show_info[-1])
+
+    def get_character_from_link(self, show_info):
+        return self.get_character(show_info[-1])

--- a/reconbot/notificationprinters/esi/printer.py
+++ b/reconbot/notificationprinters/esi/printer.py
@@ -336,22 +336,10 @@ class Printer(object):
         return 'A bounty of {0:get_isk(amount)} has been claimed for killing {0:get_character(charID)}'.format(Formatter(self, notification))
 
     def kill_report_victim(self, notification):
-        kill_mail = self.get_killmail(
-            notification['killMailID'],
-            notification['killMailHash']
-        )
-        victim_ship_type = self.get_item(notification['victimShipTypeID'])
-
-        return 'Died in a(n) %s: %s' % (victim_ship_type, kill_mail)
+        return 'Died in a(n) {0:get_item(victimShipTypeID)}: {0:get_killmail(killMailID, killMailHash)}'.format(Formatter(self, notification))
 
     def kill_report_final_blow(self, notification):
-        kill_mail = self.get_killmail(
-            notification['killMailID'],
-            notification['killMailHash']
-        )
-        victim_ship_type = self.get_item(notification['victimShipTypeID'])
-
-        return 'Got final blow on %s: %s' % (victim_ship_type, kill_mail)
+        return 'Got final blow on {0:get_item(victimShipTypeID)}: {0:get_killmail(killMailID, killMailHash)}'.format(Formatter(self, notification))
 
     @abc.abstractmethod
     def get_corporation(self, corporation_id):

--- a/reconbot/notificationprinters/esi/printer.py
+++ b/reconbot/notificationprinters/esi/printer.py
@@ -106,18 +106,7 @@ class Printer(object):
         return 'New POS anchored in "{0:get_moon(moonID)}" by {0:get_corporation(corpID)}'.format(Formatter(self, notification))
 
     def pos_attack(self, notification):
-        moon = self.get_moon(notification['moonID'])
-        attacker = self.get_character(notification['aggressorID'])
-        item_type = self.get_item(notification['typeID'])
-
-        return "%s POS \"%s\" (%.1f%% shield, %.1f%% armor, %.1f%% hull) under attack by %s" % (
-            moon,
-            item_type,
-            notification['shieldValue']*100,
-            notification['armorValue']*100,
-            notification['hullValue']*100,
-            attacker
-        )
+        return '{0:get_moon(moonID)} POS "{0:get_item(typeID)}" ({0:get_percentage(shieldValue)} shield, {0:get_percentage(armorValue)} armor, {0:get_percentage(hullValue)} hull) under attack by {0:get_character(aggressorID)}'.format(Formatter(self, notification))
 
     def pos_fuel_alert(self, notification):
         moon = self.get_moon(notification['moonID'])
@@ -134,11 +123,7 @@ class Printer(object):
         return "Station conquered from {0:get_corporation(oldOwnerID)} by {0:get_corporation(newOwnerID)} in {0:get_system(solarSystemID)}".format(Formatter(self, notification))
 
     def customs_office_attacked(self, notification):
-        attacker = self.get_character(notification['aggressorID'])
-        planet = self.get_planet(notification['planetID'])
-        shields = int(notification['shieldLevel']*100)
-
-        return "\"%s\" POCO (%d%% shields) has been attacked by %s" % (planet, shields, attacker)
+        return '"{0:get_planet(planetID)}" POCO ({0:get_percentage(shieldLevel)} shields) has been attacked by {0:get_character(aggressorID)}'.format(Formatter(self, notification))
 
     def customs_office_reinforced(self, notification):
         return '"{0:get_planet(planetID)}" POCO has been reinforced by {0:get_character(aggressorID)} (comes out of reinforce on "{0:eve_timestamp_to_date(reinforceExitTime)}")'.format(Formatter(self, notification))
@@ -300,73 +285,28 @@ class Printer(object):
         return 'Self-destruction of "{0:get_item(structureTypeID)}" SOV structure in {0:get_system(solarSystemID)} has been requested by {0:get_character(charID)}. Structure will self-destruct on "{0:eve_timestamp_to_date(destructTime)}"'.format(Formatter(self, notification))
 
     def moon_extraction_started(self, notification):
-        started_by = self.get_character(notification['startedBy'])
-        system = self.get_system(notification['solarSystemID'])
-        moon = self.get_moon(notification['moonID'])
-        ready_time = self.eve_timestamp_to_date(notification['readyTime'])
-        auto_destruct_time = self.eve_timestamp_to_date(notification['autoTime'])
-        structure_name = notification['structureName']
-
-        return 'Moon extraction started by %s in %s (%s, "%s") and will be ready on %s (or will auto-explode into a belt on %s)' % (started_by, system, moon, structure_name, ready_time, auto_destruct_time)
+        return 'Moon extraction started by {0:get_character(startedBy)} in {0:get_system(solarSystemID)} ({0:get_moon(moonID)}, "{0:get_string(structureName)}") and will be ready on {0:eve_timestamp_to_date(readyTime)} (or will auto-explode into a belt on {0:eve_timestamp_to_date(autoTime)})'.format(Formatter(self, notification))
 
     def moon_extraction_cancelled(self, notification):
-        cancelled_by = self.get_character(notification['cancelledBy'])
-        system = self.get_system(notification['solarSystemID'])
-        moon = self.get_moon(notification['moonID'])
-        structure_name = notification['structureName']
-
-        return 'Moon extraction cancelled by %s in %s (%s, "%s")' % (cancelled_by, system, moon, structure_name)
+        return 'Moon extraction cancelled by {0:get_character(cancelledBy)} in {0:get_system(solarSystemID)} ({0:get_moon(moonID)}, "{0:get_string(structureName)}")'.format(Formatter(self, notification))
 
     def moon_extraction_finished(self, notification):
-        system = self.get_system(notification['solarSystemID'])
-        moon = self.get_moon(notification['moonID'])
-        auto_destruct_time = self.eve_timestamp_to_date(notification['autoTime'])
-        structure_name = notification['structureName']
-
-        return 'Moon extraction has finished and is ready in %s (%s, "%s") to be exploded into a belt (or will auto-explode into one on %s)' % (system, moon, structure_name, auto_destruct_time)
+        return 'Moon extraction has finished and is ready in {0:get_system(solarSystemID)} ({0:get_moon(moonID)}, "{0:get_string(structureName)}") to be exploded into a belt (or will auto-explode into one on {0:eve_timestamp_to_date(autoTime)})'.format(Formatter(self, notification))
 
     def moon_extraction_turned_into_belt(self, notification):
-        fired_by = self.get_character(notification['firedBy'])
-        system = self.get_system(notification['solarSystemID'])
-        moon = self.get_moon(notification['moonID'])
-        structure_name = notification['structureName']
-
-        return 'Moon laser has been fired by %s in %s (%s, "%s") and the belt is ready to be mined' % (fired_by, system, moon, structure_name)
+        return 'Moon laser has been fired by {0:get_character(firedBy)} in {0:get_system(solarSystemID)} ({0:get_moon(moonID)}, "{0:get_string(structureName)}") and the belt is ready to be mined'.format(Formatter(self, notification))
 
     def moon_extraction_autofractured(self, notification):
-        system = self.get_system(notification['solarSystemID'])
-        moon = self.get_moon(notification['moonID'])
-        structure_name = notification['structureName']
-
-        return 'Moon extraction in %s (%s, "%s") has autofractured into a belt and is ready to be mined' % (system, moon, structure_name)
+        return 'Moon extraction in {0:get_system(solarSystemID)} ({0:get_moon(moonID)}, "{0:get_string(structureName)}") has autofractured into a belt and is ready to be mined'.format(Formatter(self, notification))
 
     def corporation_bill(self, notification):
-        debtor = self.get_corporation_or_alliance(notification['debtorID'])
-        creditor = self.get_corporation_or_alliance(notification['creditorID'])
-        current_timestamp = self.eve_timestamp_to_date(notification['currentDate'])
-        due_timestamp = self.eve_timestamp_to_date(notification['dueDate'])
-
-        return 'Corporation bill issued to %s by %s for the amount of %.2f ISK at %s. Bill is due %s' % (
-            debtor,
-            creditor,
-            notification['amount'],
-            current_timestamp,
-            due_timestamp
-        )
+        return 'Corporation bill issued to {0:get_corporation_or_alliance(debtorID)} by {0:get_corporation_or_alliance(creditorID)} for the amount of {0:get_isk(amount)} at {0:eve_timestamp_to_date(currentDate)}. Bill is due {0:eve_timestamp_to_date(dueDate)}'.format(Formatter(self, notification))
 
     def corporation_bill_paid(self, notification):
-        due_timestamp = self.eve_timestamp_to_date(notification['dueDate'])
-
-        return 'Corporation bill for %.2f ISK was paid. Bill was due %s' % (
-            notification['amount'],
-            due_timestamp
-        )
+        return 'Corporation bill for {0:get_isk(amount)} was paid. Bill was due {0:eve_timestamp_to_date(dueDate)}'.format(Formatter(self, notification))
 
     def new_character_application_to_corp(self, notification):
-        character = self.get_character(notification['charID'])
-        corporation = self.get_corporation(notification['corpID'])
-
-        return "Character %s has applied to corporation %s. Application text:\n\n%s" % (character, corporation, notification['applicationText'])
+        return 'Character {0:get_character(charID)} has applied to corporation {0:get_corporation(corpID)}. Application text:\n\n{0:get_string(applicationText)}'.format(Formatter(self, notification))
 
     def character_application_withdrawn(self, notification):
         return 'Character {0:get_character(charID)} application to corporation {0:get_corporation(corpID)} has been withdrawn'.format(Formatter(self, notification))
@@ -387,20 +327,13 @@ class Printer(object):
         return 'Corporation "{0:get_corporation(corpID)}" vote for new CEO has been revoked by {0:get_character(charID)}'.format(Formatter(self, notification))
 
     def corporation_tax_changed(self, notification):
-        corporation = self.get_corporation(notification['corpID'])
-
-        return 'Tax changed from %.1f%% to %.1f%% for %s' % (notification['oldTaxRate'], notification['newTaxRate'], corporation)
+        return 'Tax changed from {0:get_percentage(oldTaxRate)} to {0:get_percentage(newTaxRate)} for {0:get_corporation(corpID)}'.format(Formatter(self, notification))
 
     def corporation_dividend_paid_out(self, notification):
-        corporation = self.get_corporation(notification['corpID'])
-
-        return 'Corporation %s has paid out %.2f ISK in dividends' % (corporation, notification['payout'])
+        return 'Corporation {0:get_corporation(corpID)} has paid out {0:get_isk(payout)} ISK in dividends'.format(Formatter(self, notification))
 
     def bounty_claimed(self, notification):
-        character = self.get_character(notification['charID'])
-        amount = notification['amount']
-
-        return 'A bounty of %.2f ISK has been claimed for killing %s' % (amount, character)
+        return 'A bounty of {0:get_isk(amount)} has been claimed for killing {0:get_character(charID)}'.format(Formatter(self, notification))
 
     def kill_report_victim(self, notification):
         kill_mail = self.get_killmail(
@@ -498,3 +431,11 @@ class Printer(object):
         timedelta = datetime.datetime.strptime(timestamp, "%Y-%m-%dT%H:%M:%SZ") + datetime.timedelta(seconds=seconds)
         return timedelta.strftime('%Y-%m-%d %H:%M:%S')
 
+    def get_percentage(self, value):
+        return '%.1f%%' % (value * 100)
+
+    def get_isk(self, isk):
+        return '%.2f ISK' % isk
+
+    def get_string(self, value):
+        return str(value)

--- a/reconbot/notificationprinters/esi/printer.py
+++ b/reconbot/notificationprinters/esi/printer.py
@@ -84,60 +84,17 @@ class Printer(object):
         return 'Unknown notification type for printing'
 
     def corporation_war_declared(self, notification):
-        # May contain corporation or alliance IDs
-        try:
-            against_corp = self.get_corporation(notification['againstID'])
-        except:
-            against_corp = self.get_alliance(notification['againstID'])
-        try:
-            declared_by_corp = self.get_corporation(notification['declaredByID'])
-        except:
-            declared_by_corp = self.get_alliance(notification['declaredByID'])
-
-        return 'War has been declared to %s by %s' % (against_corp, declared_by_corp)
+        return 'War has been declared to {0:get_corporation_or_alliance(againstID)} by {0:get_corporation_or_alliance(declaredByID)}'.format(Formatter(self, notification))
 
     def declare_war(self, notification):
-        character = self.get_character(notification['charID'])
-        # May contain corporation or alliance IDs
-        try:
-            defender = self.get_corporation(notification['defenderID'])
-        except:
-            defender = self.get_alliance(notification['defenderID'])
-        try:
-            entity = self.get_corporation(notification['entityID'])
-        except:
-            entity = self.get_alliance(notification['entityID'])
-
-        return '%s from %s has declared war to %s' % (character, entity, defender)
+        return '{0:get_character(charID)} from {0:get_corporation_or_alliance(entityID)} has declared war to {0:get_corporation_or_alliance(defenderID)}'.format(Formatter(self, notification))
 
 
     def corporation_war_invalidated(self, notification):
-        # May contain corporation or alliance IDs
-        try:
-            against_corp = self.get_corporation(notification['againstID'])
-        except:
-            against_corp = self.get_alliance(notification['againstID'])
-        try:
-            declared_by_corp = self.get_corporation(notification['declaredByID'])
-        except:
-            declared_by_corp = self.get_alliance(notification['declaredByID'])
-
-        return 'War has been invalidated to %s by %s' % (against_corp, declared_by_corp)
+        return 'War has been invalidated to {0:get_corporation_or_alliance(againstID)} by {0:get_corporation_or_alliance(declaredByID)}'.format(Formatter(self, notification))
 
     def aggressor_ally_joined_war(self, notification):
-        # May contain corporation or alliance IDs
-        try:
-            defender = self.get_corporation(notification['defenderID'])
-        except:
-            defender = self.get_alliance(notification['defenderID'])
-        try:
-            ally = self.get_corporation(notification['allyID'])
-        except:
-            ally = self.get_alliance(notification['allyID'])
-
-        timestamp = self.eve_timestamp_to_date(notification['startTime'])
-
-        return 'Ally %s joined the war to help %s starting %s' % (ally, defender, timestamp)
+        return 'Ally {0:get_corporation_or_alliance(allyID)} joined the war to help {0:get_corporation_or_alliance(defenderID)} starting {0:eve_timestamp_to_date(startTime)}'.format(Formatter(self, notification))
 
     def sov_claim_lost(self, notification):
         return 'SOV lost in {0:get_system(solarSystemID)} by {0:get_corporation(corpID)}'.format(Formatter(self, notification))
@@ -384,14 +341,8 @@ class Printer(object):
         return 'Moon extraction in %s (%s, "%s") has autofractured into a belt and is ready to be mined' % (system, moon, structure_name)
 
     def corporation_bill(self, notification):
-        try:
-            debtor = self.get_corporation(notification['debtorID'])
-        except:
-            debtor = self.get_alliance(notification['debtorID'])
-        try:
-            creditor = self.get_corporation(notification['creditorID'])
-        except:
-            creditor = self.get_alliance(notification['creditorID'])
+        debtor = self.get_corporation_or_alliance(notification['debtorID'])
+        creditor = self.get_corporation_or_alliance(notification['creditorID'])
         current_timestamp = self.eve_timestamp_to_date(notification['currentDate'])
         due_timestamp = self.eve_timestamp_to_date(notification['dueDate'])
 
@@ -476,6 +427,12 @@ class Printer(object):
     @abc.abstractmethod
     def get_alliance(self, alliance_id):
         return
+
+    def get_corporation_or_alliance(self, entity_id):
+        try:
+            return self.get_corporation(entity_id)
+        except:
+            return self.get_alliance(entity_id)
 
     def get_item(self, item_id):
         item = self.eve.get_item(item_id)

--- a/reconbot/notificationprinters/esi/printer.py
+++ b/reconbot/notificationprinters/esi/printer.py
@@ -109,9 +109,7 @@ class Printer(object):
         return '{0:get_moon(moonID)} POS "{0:get_item(typeID)}" ({0:get_percentage(shieldValue)} shield, {0:get_percentage(armorValue)} armor, {0:get_percentage(hullValue)} hull) under attack by {0:get_character(aggressorID)}'.format(Formatter(self, notification))
 
     def pos_fuel_alert(self, notification):
-        wants = map(lambda w: '%s: %d' % (self.get_item(w['typeID']), w['quantity']), notification['wants'])
-
-        return '{0:get_moon(moonID)} POS "{0:get_item(typeID)}" is low on fuel: {wants}'.format(Formatter(self, notification), wants=', '.join(wants))
+        return '{0:get_moon(moonID)} POS "{0:get_item(typeID)}" is low on fuel: {0:get_pos_wants(wants)}'.format(Formatter(self, notification))
 
     def station_conquered(self, notification):
         return "Station conquered from {0:get_corporation(oldOwnerID)} by {0:get_corporation(newOwnerID)} in {0:get_system(solarSystemID)}".format(Formatter(self, notification))
@@ -172,9 +170,7 @@ class Printer(object):
         return 'Citadel ({0:get_structure_type_from_link(structureShowInfoData)}, "{0:get_structure_name(structureID)}") destroyed in {0:get_system(solarsystemID)} owned by {0:get_corporation_from_link(ownerCorpLinkData)}'.format(Formatter(self, notification))
 
     def citadel_out_of_fuel(self, notification):
-        services = map(lambda ID: self.get_item(ID), notification['listOfServiceModuleIDs'])
-
-        return 'Citadel ({0:get_structure_type_from_link(structureShowInfoData)}, "{0:get_structure_name(structureID)}") ran out of fuel in {0:get_system(solarsystemID)} with services "{services}"'.format(Formatter(self, notification), services=', '.join(services))
+        return 'Citadel ({0:get_structure_type_from_link(structureShowInfoData)}, "{0:get_structure_name(structureID)}") ran out of fuel in {0:get_system(solarsystemID)} with services "{0:get_citadel_services(listOfServiceModuleIDs)}"'.format(Formatter(self, notification))
 
     def structure_anchoring_alert(self, notification):
         return 'New structure ({0:get_item(typeID)}) anchored in "{0:get_moon(moonID)}" by {0:get_corporation(corpID)}'.format(Formatter(self, notification))
@@ -345,3 +341,13 @@ class Printer(object):
 
     def get_character_from_link(self, show_info):
         return self.get_character(show_info[-1])
+
+    def get_pos_wants(self, wants):
+        wants = map(lambda w: '%s: %d' % (self.get_item(w['typeID']), w['quantity']), wants)
+
+        return ', '.join(wants)
+
+    def get_citadel_services(self, modules):
+        services = map(lambda ID: self.get_item(ID), modules)
+
+        return ', '.join(services)

--- a/reconbot/notificationprinters/esi/printer.py
+++ b/reconbot/notificationprinters/esi/printer.py
@@ -79,167 +79,170 @@ class Printer(object):
         if notification['type'] in types:
             text = yaml.load(notification['text'])
             text['notification_timestamp'] = notification['timestamp']
-            return types[notification['type']](text)
+            template = types[notification['type']]()
+
+            rendered_notification = template.format(Formatter(self, text))
+            return rendered_notification
 
         return 'Unknown notification type for printing'
 
-    def corporation_war_declared(self, notification):
-        return 'War has been declared to {0:get_corporation_or_alliance(againstID)} by {0:get_corporation_or_alliance(declaredByID)}'.format(Formatter(self, notification))
+    def corporation_war_declared(self):
+        return 'War has been declared to {0:get_corporation_or_alliance(againstID)} by {0:get_corporation_or_alliance(declaredByID)}'
 
-    def declare_war(self, notification):
-        return '{0:get_character(charID)} from {0:get_corporation_or_alliance(entityID)} has declared war to {0:get_corporation_or_alliance(defenderID)}'.format(Formatter(self, notification))
-
-
-    def corporation_war_invalidated(self, notification):
-        return 'War has been invalidated to {0:get_corporation_or_alliance(againstID)} by {0:get_corporation_or_alliance(declaredByID)}'.format(Formatter(self, notification))
-
-    def aggressor_ally_joined_war(self, notification):
-        return 'Ally {0:get_corporation_or_alliance(allyID)} joined the war to help {0:get_corporation_or_alliance(defenderID)} starting {0:eve_timestamp_to_date(startTime)}'.format(Formatter(self, notification))
-
-    def sov_claim_lost(self, notification):
-        return 'SOV lost in {0:get_system(solarSystemID)} by {0:get_corporation(corpID)}'.format(Formatter(self, notification))
-
-    def sov_claim_acquired(self, notification):
-        return 'SOV acquired in {0:get_system(solarSystemID)} by {0:get_corporation(corpID)}'.format(Formatter(self, notification))
-
-    def pos_anchoring_alert(self, notification):
-        return 'New POS anchored in "{0:get_moon(moonID)}" by {0:get_corporation(corpID)}'.format(Formatter(self, notification))
-
-    def pos_attack(self, notification):
-        return '{0:get_moon(moonID)} POS "{0:get_item(typeID)}" ({0:get_percentage(shieldValue)} shield, {0:get_percentage(armorValue)} armor, {0:get_percentage(hullValue)} hull) under attack by {0:get_character(aggressorID)}'.format(Formatter(self, notification))
-
-    def pos_fuel_alert(self, notification):
-        return '{0:get_moon(moonID)} POS "{0:get_item(typeID)}" is low on fuel: {0:get_pos_wants(wants)}'.format(Formatter(self, notification))
-
-    def station_conquered(self, notification):
-        return "Station conquered from {0:get_corporation(oldOwnerID)} by {0:get_corporation(newOwnerID)} in {0:get_system(solarSystemID)}".format(Formatter(self, notification))
-
-    def customs_office_attacked(self, notification):
-        return '"{0:get_planet(planetID)}" POCO ({0:get_percentage(shieldLevel)} shields) has been attacked by {0:get_character(aggressorID)}'.format(Formatter(self, notification))
-
-    def customs_office_reinforced(self, notification):
-        return '"{0:get_planet(planetID)}" POCO has been reinforced by {0:get_character(aggressorID)} (comes out of reinforce on "{0:eve_timestamp_to_date(reinforceExitTime)}")'.format(Formatter(self, notification))
-
-    def structure_transferred(self, notification):
-        return '"{0:get_string(structureName)}" structure in {0:get_system_from_link(solarSystemLinkData)} has been transferred from {0:get_corporation_from_link(fromCorporationLinkData)} to {0:get_corporation_from_link(toCorporationLinkData)} by {0:get_character_from_link(characterLinkData)}'.format(Formatter(self, notification))
-
-    def entosis_capture_started(self, notification):
-        return 'Capturing of "{0:get_item(structureTypeID)}" in {0:get_system(solarSystemID)} has started'.format(Formatter(self, notification))
-
-    def entosis_enabled_structure(self, notification):
-        return 'Structure "{0:get_item(structureTypeID)}" in {0:get_system(solarSystemID)} has been enabled'.format(Formatter(self, notification))
-
-    def entosis_disabled_structure(self, notification):
-        return 'Structure "{0:get_item(structureTypeID)}" in {0:get_system(solarSystemID)} has been disabled'.format(Formatter(self, notification))
-
-    def sov_structure_reinforced(self, notification):
-        return 'SOV structure "{0:get_campaign_event_type(campaignEventType)}" in {0:get_system(solarSystemID)} has been reinforced, nodes will decloak "{0:eve_timestamp_to_date(decloakTime)}"'.format(Formatter(self, notification))
-
-    def sov_structure_command_nodes_decloaked(self, notification):
-        return 'Command nodes for "{0:get_campaign_event_type(campaignEventType)}" SOV structure in {0:get_system(solarSystemID)} have decloaked'.format(Formatter(self, notification))
-
-    def sov_structure_destroyed(self, notification):
-        return 'SOV structure "{0:get_item(structureTypeID)}" in {0:get_system(solarSystemID)} has been destroyed'.format(Formatter(self, notification))
-
-    def sov_structure_freeported(self, notification):
-        return 'SOV structure "{0:get_item(structureTypeID)}" in {0:get_system(solarSystemID)} has been freeported, exits freeport on "{0:eve_timestamp_to_date(freeportexittime)}"'.format(Formatter(self, notification))
-
-    def citadel_low_fuel(self, notification):
-        return 'Citadel ({0:get_structure_type_from_link(structureShowInfoData)}, "{0:get_structure_name(structureID)}") low fuel alert in {0:get_system(solarsystemID)}'.format(Formatter(self, notification))
-
-    def citadel_anchored(self, notification):
-        return 'Citadel ({0:get_structure_type_from_link(structureShowInfoData)}, "{0:get_structure_name(structureID)}") anchored in {0:get_system(solarsystemID)} by {0:get_corporation_from_link(ownerCorpLinkData)}'.format(Formatter(self, notification))
-
-    def citadel_unanchoring(self, notification):
-        return 'Citadel ({0:get_structure_type_from_link(structureShowInfoData)}, "{0:get_structure_name(structureID)}") unanchoring in {0:get_system(solarsystemID)} by {0:get_corporation_from_link(ownerCorpLinkData)}'.format(Formatter(self, notification))
+    def declare_war(self):
+        return '{0:get_character(charID)} from {0:get_corporation_or_alliance(entityID)} has declared war to {0:get_corporation_or_alliance(defenderID)}'
 
 
-    def citadel_attacked(self, notification):
-        return 'Citadel ({0:get_structure_type_from_link(structureShowInfoData)}, "{0:get_structure_name(structureID)}") attacked ({0:get_percentage(shieldPercentage)} shield, {0:get_percentage(armorPercentage)} armor, {0:get_percentage(hullPercentage)} hull) in {0:get_system(solarsystemID)} by {0:get_character(charID)}'.format(Formatter(self, notification))
+    def corporation_war_invalidated(self):
+        return 'War has been invalidated to {0:get_corporation_or_alliance(againstID)} by {0:get_corporation_or_alliance(declaredByID)}'
 
-    def citadel_onlined(self, notification):
-        return 'Citadel ({0:get_structure_type_from_link(structureShowInfoData)}, "{0:get_structure_name(structureID)}") onlined in {0:get_system(solarsystemID)}'.format(Formatter(self, notification))
+    def aggressor_ally_joined_war(self):
+        return 'Ally {0:get_corporation_or_alliance(allyID)} joined the war to help {0:get_corporation_or_alliance(defenderID)} starting {0:eve_timestamp_to_date(startTime)}'
 
-    def citadel_lost_shields(self, notification):
-        return 'Citadel ({0:get_structure_type_from_link(structureShowInfoData)}, "{0:get_structure_name(structureID)}") lost shields in {0:get_system(solarsystemID)} (comes out of reinforce on "{0:eve_duration_to_date(notification_timestamp, timeLeft)}")'.format(Formatter(self, notification))
+    def sov_claim_lost(self):
+        return 'SOV lost in {0:get_system(solarSystemID)} by {0:get_corporation(corpID)}'
 
-    def citadel_lost_armor(self, notification):
-        return 'Citadel ({0:get_structure_type_from_link(structureShowInfoData)}, "{0:get_structure_name(structureID)}") lost armor in {0:get_system(solarsystemID)} (comes out of reinforce on "{0:eve_duration_to_date(notification_timestamp, timeLeft)}")'.format(Formatter(self, notification))
+    def sov_claim_acquired(self):
+        return 'SOV acquired in {0:get_system(solarSystemID)} by {0:get_corporation(corpID)}'
 
-    def citadel_destroyed(self, notification):
-        return 'Citadel ({0:get_structure_type_from_link(structureShowInfoData)}, "{0:get_structure_name(structureID)}") destroyed in {0:get_system(solarsystemID)} owned by {0:get_corporation_from_link(ownerCorpLinkData)}'.format(Formatter(self, notification))
+    def pos_anchoring_alert(self):
+        return 'New POS anchored in "{0:get_moon(moonID)}" by {0:get_corporation(corpID)}'
 
-    def citadel_out_of_fuel(self, notification):
-        return 'Citadel ({0:get_structure_type_from_link(structureShowInfoData)}, "{0:get_structure_name(structureID)}") ran out of fuel in {0:get_system(solarsystemID)} with services "{0:get_citadel_services(listOfServiceModuleIDs)}"'.format(Formatter(self, notification))
+    def pos_attack(self):
+        return '{0:get_moon(moonID)} POS "{0:get_item(typeID)}" ({0:get_percentage(shieldValue)} shield, {0:get_percentage(armorValue)} armor, {0:get_percentage(hullValue)} hull) under attack by {0:get_character(aggressorID)}'
 
-    def structure_anchoring_alert(self, notification):
-        return 'New structure ({0:get_item(typeID)}) anchored in "{0:get_moon(moonID)}" by {0:get_corporation(corpID)}'.format(Formatter(self, notification))
+    def pos_fuel_alert(self):
+        return '{0:get_moon(moonID)} POS "{0:get_item(typeID)}" is low on fuel: {0:get_pos_wants(wants)}'
 
-    def ihub_bill_about_to_expire(self, notification):
-        return 'IHUB bill to {0:get_corporation(corpID)} for system {0:get_system(solarSystemID)} will expire {0:eve_timestamp_to_date(dueDate)}'.format(Formatter(self, notification))
+    def station_conquered(self):
+        return "Station conquered from {0:get_corporation(oldOwnerID)} by {0:get_corporation(newOwnerID)} in {0:get_system(solarSystemID)}"
 
-    def sov_structure_self_destructed(self, notification):
-        return 'SOV structure "{0:get_item(structureTypeID)}" has self destructed in {0:get_system(solarSystemID)}'.format(Formatter(self, notification))
+    def customs_office_attacked(self):
+        return '"{0:get_planet(planetID)}" POCO ({0:get_percentage(shieldLevel)} shields) has been attacked by {0:get_character(aggressorID)}'
 
-    def sov_structure_started_self_destructing(self, notification):
-        return 'Self-destruction of "{0:get_item(structureTypeID)}" SOV structure in {0:get_system(solarSystemID)} has been requested by {0:get_character(charID)}. Structure will self-destruct on "{0:eve_timestamp_to_date(destructTime)}"'.format(Formatter(self, notification))
+    def customs_office_reinforced(self):
+        return '"{0:get_planet(planetID)}" POCO has been reinforced by {0:get_character(aggressorID)} (comes out of reinforce on "{0:eve_timestamp_to_date(reinforceExitTime)}")'
 
-    def moon_extraction_started(self, notification):
-        return 'Moon extraction started by {0:get_character(startedBy)} in {0:get_system(solarSystemID)} ({0:get_moon(moonID)}, "{0:get_string(structureName)}") and will be ready on {0:eve_timestamp_to_date(readyTime)} (or will auto-explode into a belt on {0:eve_timestamp_to_date(autoTime)})'.format(Formatter(self, notification))
+    def structure_transferred(self):
+        return '"{0:get_string(structureName)}" structure in {0:get_system_from_link(solarSystemLinkData)} has been transferred from {0:get_corporation_from_link(fromCorporationLinkData)} to {0:get_corporation_from_link(toCorporationLinkData)} by {0:get_character_from_link(characterLinkData)}'
 
-    def moon_extraction_cancelled(self, notification):
-        return 'Moon extraction cancelled by {0:get_character(cancelledBy)} in {0:get_system(solarSystemID)} ({0:get_moon(moonID)}, "{0:get_string(structureName)}")'.format(Formatter(self, notification))
+    def entosis_capture_started(self):
+        return 'Capturing of "{0:get_item(structureTypeID)}" in {0:get_system(solarSystemID)} has started'
 
-    def moon_extraction_finished(self, notification):
-        return 'Moon extraction has finished and is ready in {0:get_system(solarSystemID)} ({0:get_moon(moonID)}, "{0:get_string(structureName)}") to be exploded into a belt (or will auto-explode into one on {0:eve_timestamp_to_date(autoTime)})'.format(Formatter(self, notification))
+    def entosis_enabled_structure(self):
+        return 'Structure "{0:get_item(structureTypeID)}" in {0:get_system(solarSystemID)} has been enabled'
 
-    def moon_extraction_turned_into_belt(self, notification):
-        return 'Moon laser has been fired by {0:get_character(firedBy)} in {0:get_system(solarSystemID)} ({0:get_moon(moonID)}, "{0:get_string(structureName)}") and the belt is ready to be mined'.format(Formatter(self, notification))
+    def entosis_disabled_structure(self):
+        return 'Structure "{0:get_item(structureTypeID)}" in {0:get_system(solarSystemID)} has been disabled'
 
-    def moon_extraction_autofractured(self, notification):
-        return 'Moon extraction in {0:get_system(solarSystemID)} ({0:get_moon(moonID)}, "{0:get_string(structureName)}") has autofractured into a belt and is ready to be mined'.format(Formatter(self, notification))
+    def sov_structure_reinforced(self):
+        return 'SOV structure "{0:get_campaign_event_type(campaignEventType)}" in {0:get_system(solarSystemID)} has been reinforced, nodes will decloak "{0:eve_timestamp_to_date(decloakTime)}"'
 
-    def corporation_bill(self, notification):
-        return 'Corporation bill issued to {0:get_corporation_or_alliance(debtorID)} by {0:get_corporation_or_alliance(creditorID)} for the amount of {0:get_isk(amount)} at {0:eve_timestamp_to_date(currentDate)}. Bill is due {0:eve_timestamp_to_date(dueDate)}'.format(Formatter(self, notification))
+    def sov_structure_command_nodes_decloaked(self):
+        return 'Command nodes for "{0:get_campaign_event_type(campaignEventType)}" SOV structure in {0:get_system(solarSystemID)} have decloaked'
 
-    def corporation_bill_paid(self, notification):
-        return 'Corporation bill for {0:get_isk(amount)} was paid. Bill was due {0:eve_timestamp_to_date(dueDate)}'.format(Formatter(self, notification))
+    def sov_structure_destroyed(self):
+        return 'SOV structure "{0:get_item(structureTypeID)}" in {0:get_system(solarSystemID)} has been destroyed'
 
-    def new_character_application_to_corp(self, notification):
-        return 'Character {0:get_character(charID)} has applied to corporation {0:get_corporation(corpID)}. Application text:\n\n{0:get_string(applicationText)}'.format(Formatter(self, notification))
+    def sov_structure_freeported(self):
+        return 'SOV structure "{0:get_item(structureTypeID)}" in {0:get_system(solarSystemID)} has been freeported, exits freeport on "{0:eve_timestamp_to_date(freeportexittime)}"'
 
-    def character_application_withdrawn(self, notification):
-        return 'Character {0:get_character(charID)} application to corporation {0:get_corporation(corpID)} has been withdrawn'.format(Formatter(self, notification))
+    def citadel_low_fuel(self):
+        return 'Citadel ({0:get_structure_type_from_link(structureShowInfoData)}, "{0:get_structure_name(structureID)}") low fuel alert in {0:get_system(solarsystemID)}'
 
-    def character_application_accepted(self, notification):
-        return 'Character {0:get_character(charID)} accepted to corporation {0:get_corporation(corpID)}'.format(Formatter(self, notification))
+    def citadel_anchored(self):
+        return 'Citadel ({0:get_structure_type_from_link(structureShowInfoData)}, "{0:get_structure_name(structureID)}") anchored in {0:get_system(solarsystemID)} by {0:get_corporation_from_link(ownerCorpLinkData)}'
 
-    def character_left_corporation(self, notification):
-        return 'Character {0:get_character(charID)} left corporation {0:get_corporation(corpID)}'.format(Formatter(self, notification))
+    def citadel_unanchoring(self):
+        return 'Citadel ({0:get_structure_type_from_link(structureShowInfoData)}, "{0:get_structure_name(structureID)}") unanchoring in {0:get_system(solarsystemID)} by {0:get_corporation_from_link(ownerCorpLinkData)}'
 
-    def new_corporation_ceo(self, notification):
-        return '{0:get_character(newCeoID)} has replaced {0:get_character(oldCeoID)} as the new CEO of {0:get_corporation(corpID)}'.format(Formatter(self, notification))
 
-    def corporation_vote_initiated(self, notification):
-        return "New corporation vote for '%s':\n\n%s" % (notification['subject'], notification['body'])
+    def citadel_attacked(self):
+        return 'Citadel ({0:get_structure_type_from_link(structureShowInfoData)}, "{0:get_structure_name(structureID)}") attacked ({0:get_percentage(shieldPercentage)} shield, {0:get_percentage(armorPercentage)} armor, {0:get_percentage(hullPercentage)} hull) in {0:get_system(solarsystemID)} by {0:get_character(charID)}'
 
-    def corporation_vote_for_ceo_revoked(self, notification):
-        return 'Corporation "{0:get_corporation(corpID)}" vote for new CEO has been revoked by {0:get_character(charID)}'.format(Formatter(self, notification))
+    def citadel_onlined(self):
+        return 'Citadel ({0:get_structure_type_from_link(structureShowInfoData)}, "{0:get_structure_name(structureID)}") onlined in {0:get_system(solarsystemID)}'
 
-    def corporation_tax_changed(self, notification):
-        return 'Tax changed from {0:get_percentage(oldTaxRate)} to {0:get_percentage(newTaxRate)} for {0:get_corporation(corpID)}'.format(Formatter(self, notification))
+    def citadel_lost_shields(self):
+        return 'Citadel ({0:get_structure_type_from_link(structureShowInfoData)}, "{0:get_structure_name(structureID)}") lost shields in {0:get_system(solarsystemID)} (comes out of reinforce on "{0:eve_duration_to_date(notification_timestamp, timeLeft)}")'
 
-    def corporation_dividend_paid_out(self, notification):
-        return 'Corporation {0:get_corporation(corpID)} has paid out {0:get_isk(payout)} ISK in dividends'.format(Formatter(self, notification))
+    def citadel_lost_armor(self):
+        return 'Citadel ({0:get_structure_type_from_link(structureShowInfoData)}, "{0:get_structure_name(structureID)}") lost armor in {0:get_system(solarsystemID)} (comes out of reinforce on "{0:eve_duration_to_date(notification_timestamp, timeLeft)}")'
 
-    def bounty_claimed(self, notification):
-        return 'A bounty of {0:get_isk(amount)} has been claimed for killing {0:get_character(charID)}'.format(Formatter(self, notification))
+    def citadel_destroyed(self):
+        return 'Citadel ({0:get_structure_type_from_link(structureShowInfoData)}, "{0:get_structure_name(structureID)}") destroyed in {0:get_system(solarsystemID)} owned by {0:get_corporation_from_link(ownerCorpLinkData)}'
 
-    def kill_report_victim(self, notification):
-        return 'Died in a(n) {0:get_item(victimShipTypeID)}: {0:get_killmail(killMailID, killMailHash)}'.format(Formatter(self, notification))
+    def citadel_out_of_fuel(self):
+        return 'Citadel ({0:get_structure_type_from_link(structureShowInfoData)}, "{0:get_structure_name(structureID)}") ran out of fuel in {0:get_system(solarsystemID)} with services "{0:get_citadel_services(listOfServiceModuleIDs)}"'
 
-    def kill_report_final_blow(self, notification):
-        return 'Got final blow on {0:get_item(victimShipTypeID)}: {0:get_killmail(killMailID, killMailHash)}'.format(Formatter(self, notification))
+    def structure_anchoring_alert(self):
+        return 'New structure ({0:get_item(typeID)}) anchored in "{0:get_moon(moonID)}" by {0:get_corporation(corpID)}'
+
+    def ihub_bill_about_to_expire(self):
+        return 'IHUB bill to {0:get_corporation(corpID)} for system {0:get_system(solarSystemID)} will expire {0:eve_timestamp_to_date(dueDate)}'
+
+    def sov_structure_self_destructed(self):
+        return 'SOV structure "{0:get_item(structureTypeID)}" has self destructed in {0:get_system(solarSystemID)}'
+
+    def sov_structure_started_self_destructing(self):
+        return 'Self-destruction of "{0:get_item(structureTypeID)}" SOV structure in {0:get_system(solarSystemID)} has been requested by {0:get_character(charID)}. Structure will self-destruct on "{0:eve_timestamp_to_date(destructTime)}"'
+
+    def moon_extraction_started(self):
+        return 'Moon extraction started by {0:get_character(startedBy)} in {0:get_system(solarSystemID)} ({0:get_moon(moonID)}, "{0:get_string(structureName)}") and will be ready on {0:eve_timestamp_to_date(readyTime)} (or will auto-explode into a belt on {0:eve_timestamp_to_date(autoTime)})'
+
+    def moon_extraction_cancelled(self):
+        return 'Moon extraction cancelled by {0:get_character(cancelledBy)} in {0:get_system(solarSystemID)} ({0:get_moon(moonID)}, "{0:get_string(structureName)}")'
+
+    def moon_extraction_finished(self):
+        return 'Moon extraction has finished and is ready in {0:get_system(solarSystemID)} ({0:get_moon(moonID)}, "{0:get_string(structureName)}") to be exploded into a belt (or will auto-explode into one on {0:eve_timestamp_to_date(autoTime)})'
+
+    def moon_extraction_turned_into_belt(self):
+        return 'Moon laser has been fired by {0:get_character(firedBy)} in {0:get_system(solarSystemID)} ({0:get_moon(moonID)}, "{0:get_string(structureName)}") and the belt is ready to be mined'
+
+    def moon_extraction_autofractured(self):
+        return 'Moon extraction in {0:get_system(solarSystemID)} ({0:get_moon(moonID)}, "{0:get_string(structureName)}") has autofractured into a belt and is ready to be mined'
+
+    def corporation_bill(self):
+        return 'Corporation bill issued to {0:get_corporation_or_alliance(debtorID)} by {0:get_corporation_or_alliance(creditorID)} for the amount of {0:get_isk(amount)} at {0:eve_timestamp_to_date(currentDate)}. Bill is due {0:eve_timestamp_to_date(dueDate)}'
+
+    def corporation_bill_paid(self):
+        return 'Corporation bill for {0:get_isk(amount)} was paid. Bill was due {0:eve_timestamp_to_date(dueDate)}'
+
+    def new_character_application_to_corp(self):
+        return 'Character {0:get_character(charID)} has applied to corporation {0:get_corporation(corpID)}. Application text:\n\n{0:get_string(applicationText)}'
+
+    def character_application_withdrawn(self):
+        return 'Character {0:get_character(charID)} application to corporation {0:get_corporation(corpID)} has been withdrawn'
+
+    def character_application_accepted(self):
+        return 'Character {0:get_character(charID)} accepted to corporation {0:get_corporation(corpID)}'
+
+    def character_left_corporation(self):
+        return 'Character {0:get_character(charID)} left corporation {0:get_corporation(corpID)}'
+
+    def new_corporation_ceo(self):
+        return '{0:get_character(newCeoID)} has replaced {0:get_character(oldCeoID)} as the new CEO of {0:get_corporation(corpID)}'
+
+    def corporation_vote_initiated(self):
+        return 'New corporation vote for "{0:get_string(subject)}":\n\n{0:get_string(body)}'
+
+    def corporation_vote_for_ceo_revoked(self):
+        return 'Corporation "{0:get_corporation(corpID)}" vote for new CEO has been revoked by {0:get_character(charID)}'
+
+    def corporation_tax_changed(self):
+        return 'Tax changed from {0:get_percentage(oldTaxRate)} to {0:get_percentage(newTaxRate)} for {0:get_corporation(corpID)}'
+
+    def corporation_dividend_paid_out(self):
+        return 'Corporation {0:get_corporation(corpID)} has paid out {0:get_isk(payout)} ISK in dividends'
+
+    def bounty_claimed(self):
+        return 'A bounty of {0:get_isk(amount)} has been claimed for killing {0:get_character(charID)}'
+
+    def kill_report_victim(self):
+        return 'Died in a(n) {0:get_item(victimShipTypeID)}: {0:get_killmail(killMailID, killMailHash)}'
+
+    def kill_report_final_blow(self):
+        return 'Got final blow on {0:get_item(victimShipTypeID)}: {0:get_killmail(killMailID, killMailHash)}'
 
     @abc.abstractmethod
     def get_corporation(self, corporation_id):

--- a/tests/notificationprinters/esi/test_formatter.py
+++ b/tests/notificationprinters/esi/test_formatter.py
@@ -1,0 +1,42 @@
+import yaml
+from unittest import TestCase
+from unittest.mock import Mock, call
+
+from reconbot.notificationprinters.esi.formatter import Formatter
+
+class SlackTest(TestCase):
+    def setUp(self):
+        self.printer = Mock()
+        self.notification = {
+            'againstID': 12345,
+            'declaredByID': 23456
+        }
+
+        self.formatter = Formatter(self.printer, self.notification)
+
+    def test_calls_printer_method_with_given_arg(self):
+        self.printer.corporation_or_alliance.return_value = 'Some Corp'
+
+        'War declared against {:corporation_or_alliance(againstID)}'.format(self.formatter)
+
+        self.printer.corporation_or_alliance.assert_called_once_with(
+            self.notification['againstID']
+        )
+
+    def test_formats_text_with_given_arg(self):
+        self.printer.corporation_or_alliance.return_value = 'Some Corp'
+
+        self.assertEqual(
+            'War declared against {:corporation_or_alliance(againstID)}'.format(self.formatter),
+            'War declared against Some Corp'
+        )
+
+    def test_using_unknown_method_raises_exception(self):
+        self.printer.unknown_method.side_effect = Exception("AttributeError: 'dict' object has no attribute 'unknown_method'")
+
+        with self.assertRaises(Exception):
+            'War declared against {:unknown_method(againstID)}'.format(self.formatter)
+
+    def test_using_unknown_attribute_raises_exception(self):
+        with self.assertRaises(Exception):
+            'War declared against {:some_method(unknown_attribute)}'.format(self.formatter)

--- a/tests/notificationprinters/esi/test_formatter.py
+++ b/tests/notificationprinters/esi/test_formatter.py
@@ -23,6 +23,16 @@ class SlackTest(TestCase):
             self.notification['againstID']
         )
 
+    def test_calls_printer_method_with_multiple_given_args(self):
+        self.printer.get_killmail.return_value = 'Some Killmail'
+
+        'Erebus was killed {0:get_killmail(againstID, declaredByID)}'.format(self.formatter)
+
+        self.printer.get_killmail.assert_called_once_with(
+            self.notification['againstID'],
+            self.notification['declaredByID']
+        )
+
     def test_formats_text_with_given_arg(self):
         self.printer.corporation_or_alliance.return_value = 'Some Corp'
 

--- a/tests/notificationprinters/esi/test_slack.py
+++ b/tests/notificationprinters/esi/test_slack.py
@@ -818,3 +818,20 @@ class SlackTest(TestCase):
         self.eve_mock.get_character.assert_called_once_with(
             self.ccp_falcon['id']
         )
+
+    def test_get_pos_wants(self):
+        self.assertEqual(
+            self.printer.get_pos_wants([{'typeID': self.amarr_control_tower['id'], 'quantity': 5}]),
+            'Amarr Control Tower: 5'
+        )
+
+    def test_get_citadel_services(self):
+        self.eve_mock.get_item.return_value = self.standup_cloning_center
+        self.assertEqual(
+            self.printer.get_citadel_services([self.standup_cloning_center['id']]),
+            self.standup_cloning_center['name']
+        )
+
+        self.eve_mock.get_item.assert_called_once_with(
+            self.standup_cloning_center['id']
+        )

--- a/tests/notificationprinters/esi/test_slack.py
+++ b/tests/notificationprinters/esi/test_slack.py
@@ -771,6 +771,50 @@ class SlackTest(TestCase):
         self.assertEqual(self.printer.get_percentage(0.176), '17.6%')
         self.assertEqual(self.printer.get_percentage(0.1768), '17.7%')
 
+        self.assertEqual(self.printer.get_percentage(17), '17.0%')
+        self.assertEqual(self.printer.get_percentage(17.6), '17.6%')
+        self.assertEqual(self.printer.get_percentage(17.68), '17.7%')
+
     def test_get_string(self):
         self.assertEqual(self.printer.get_string(123), '123')
         self.assertEqual(self.printer.get_string(123.7), '123.7')
+
+
+    def test_get_corporation_from_link(self):
+        self.assertEqual(
+            self.printer.get_corporation_from_link(['showinfo', 2, self.ccp_corporation['id']]),
+            '<https://zkillboard.com/corporation/98356193/|C C P Alliance Holding> (<https://zkillboard.com/alliance/434243723/|C C P Alliance>)'
+        )
+        self.eve_mock.get_corporation.assert_called_once_with(
+            self.ccp_corporation['id']
+        )
+
+    def test_get_structure_type_from_link(self):
+        self.eve_mock.get_item.return_value = self.astrahus
+        self.assertEqual(
+            self.printer.get_structure_type_from_link(['showinfo', self.astrahus['id'], 1021121988766]),
+            self.astrahus['name']
+        )
+        self.eve_mock.get_item.assert_called_once_with(
+            self.astrahus['id']
+        )
+
+    def test_get_system_from_link(self):
+        self.assertEqual(
+            self.printer.get_system_from_link(['showinfo', 5, self.hed_gp['id']]),
+            '<http://evemaps.dotlan.net/system/HED-GP|HED-GP>'
+        )
+
+        self.eve_mock.get_system.assert_called_once_with(
+            self.hed_gp['id']
+        )
+
+    def test_get_character_from_link(self):
+        self.assertEqual(
+            self.printer.get_character_from_link(['showinfo', 1377, self.ccp_falcon['id']]),
+            '<https://zkillboard.com/character/92532650/|CCP Falcon> (<https://zkillboard.com/corporation/98356193/|C C P Alliance Holding> (<https://zkillboard.com/alliance/434243723/|C C P Alliance>))'
+        )
+
+        self.eve_mock.get_character.assert_called_once_with(
+            self.ccp_falcon['id']
+        )

--- a/tests/notificationprinters/esi/test_slack.py
+++ b/tests/notificationprinters/esi/test_slack.py
@@ -187,6 +187,33 @@ class SlackTest(TestCase):
             self.ccp_alliance['id']
         )
 
+    def test_get_corporation_or_alliance_returns_corporation(self):
+        self.eve_mock.get_corporation.return_value = self.corp_without_alliance
+
+        self.assertEqual(
+            self.printer.get_corporation_or_alliance(self.corp_without_alliance['id']),
+            '<https://zkillboard.com/corporation/998877654/|Allianceless Corporation>'
+        )
+
+        self.eve_mock.get_corporation.assert_called_once_with(
+            self.corp_without_alliance['id']
+        )
+
+    def test_get_corporation_or_alliance_returns_alliance(self):
+        self.eve_mock.get_corporation.side_effect = Exception("Corporation not found")
+
+        self.assertEqual(
+            self.printer.get_corporation_or_alliance(self.ccp_alliance['id']),
+            '<https://zkillboard.com/alliance/434243723/|C C P Alliance>'
+        )
+
+        self.eve_mock.get_corporation.assert_called_once_with(
+            self.ccp_alliance['id']
+        )
+        self.eve_mock.get_alliance.assert_called_once_with(
+            self.ccp_alliance['id']
+        )
+
     def test_get_character(self):
         self.assertEqual(
             self.printer.get_character(self.ccp_falcon['id']),

--- a/tests/notificationprinters/esi/test_slack.py
+++ b/tests/notificationprinters/esi/test_slack.py
@@ -430,7 +430,7 @@ class SlackTest(TestCase):
 
         self.assertEqual(
             self.printer.get_notification_text(notification),
-            '"HED-GP I in <http://evemaps.dotlan.net/system/HED-GP|HED-GP>" POCO (91% shields) has been attacked by <https://zkillboard.com/character/92532650/|CCP Falcon> (<https://zkillboard.com/corporation/98356193/|C C P Alliance Holding> (<https://zkillboard.com/alliance/434243723/|C C P Alliance>))'
+            '"HED-GP I in <http://evemaps.dotlan.net/system/HED-GP|HED-GP>" POCO (91.7% shields) has been attacked by <https://zkillboard.com/character/92532650/|CCP Falcon> (<https://zkillboard.com/corporation/98356193/|C C P Alliance Holding> (<https://zkillboard.com/alliance/434243723/|C C P Alliance>))'
         )
 
     def test_poco_reinforce(self):
@@ -765,3 +765,12 @@ class SlackTest(TestCase):
             self.printer.get_notification_text(notification),
             'Got final blow on Atron: <https://zkillboard.com/character/92532650/|CCP Falcon> (<https://zkillboard.com/corporation/98356193/|C C P Alliance Holding> (<https://zkillboard.com/alliance/434243723/|C C P Alliance>)) lost a(n) Atron in <http://evemaps.dotlan.net/system/HED-GP|HED-GP> (<https://zkillboard.com/kill/123/|Zkillboard>)'
         )
+
+    def test_get_percentage(self):
+        self.assertEqual(self.printer.get_percentage(0.17), '17.0%')
+        self.assertEqual(self.printer.get_percentage(0.176), '17.6%')
+        self.assertEqual(self.printer.get_percentage(0.1768), '17.7%')
+
+    def test_get_string(self):
+        self.assertEqual(self.printer.get_string(123), '123')
+        self.assertEqual(self.printer.get_string(123.7), '123.7')

--- a/tests/notificationprinters/esi/test_slack.py
+++ b/tests/notificationprinters/esi/test_slack.py
@@ -231,6 +231,16 @@ class SlackTest(TestCase):
             self.hed_gp['id']
         )
 
+    def test_get_moon(self):
+        self.assertEqual(
+            self.printer.get_moon(self.hed_gp_moon['id']),
+            'HED-GP II - Moon 1'
+        )
+
+        self.eve_mock.get_moon.assert_called_once_with(
+            self.hed_gp_moon['id']
+        )
+
     def test_get_item(self):
         self.assertEqual(
             self.printer.get_item(self.amarr_control_tower['id']),


### PR DESCRIPTION
Refactors notification printing logic to use basic templating to fomat individual entities.
Doing so reduces code duplication and allows for easier code reuse.

E.g.
```
SOV acquired in {0:get_system(solarSystemID)} by {0:get_corporation(corpID)}
```
